### PR TITLE
fix: handling of 'href' and 'src' attributes in 'cheerio' processing.

### DIFF
--- a/src/utils/getUriList.js
+++ b/src/utils/getUriList.js
@@ -51,9 +51,15 @@ const getUriListHtml = node => {
     const tag = $(elem).prop('tagName').toLowerCase();
 
     if (tag === 'a') {
-      uriList.push($(elem).attr('href'), 'link');
+      const href = $(elem).attr('href');
+      if (href) {
+        uriList.push(href, 'link');
+      }
     } else if (tag === 'img') {
-      uriList.push($(elem).attr('src'), 'image');
+      const src = $(elem).attr('src');
+      if (src) {
+        uriList.push(src, 'image');
+      }
     }
   });
 


### PR DESCRIPTION
# Handling of `href` and `src` attributes in `cheerio` processing. (`src/utils/getUriList.js`)

## Summary

When processing `a` tags using `cheerio`, if an `a` tag does not have an `href` attribute, `$('a').attr('href')` returns `undefined`. In the original implementation, this resulted in `undefined` values being pushed into the `uriList` array, which could cause unexpected behavior when processing these values later on.

## Details

### Example

For example, given the following HTML:

```html
<a id='myId'>myId</a>
```

The code would previously execute `uriList.push(undefined, 'link');`, adding an `undefined` entry to the `uriList` array and making an error like below.

![image](https://github.com/user-attachments/assets/beb663e4-961d-42e8-8096-c283d75b0ce2)


### Solution

To address this issue, the code has been updated to check for the existence of the `href` or `src` attributes before pushing them to the `uriList`. Now, only valid URIs will be added to the list.

With this change, only `a` tags with a valid `href` attribute and `img` tags with a valid `src` attribute will have their URIs added to `uriList`.

### Impact

This fix prevents `undefined` values from being added to `uriList`, ensuring that only valid and meaningful data is processed. This improves the robustness and reliability of the code when working with HTML content that may have missing `href` or `src` attributes.
