### PR TITLE
release(patch): v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A textlint rule for checking allowed URIs in links and images of Markdown.🔥",
   "main": "build/textlint-rule-allowed-uris.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-textlint-rule-allowed-uris` from v1.0.1 to v1.0.2 :tada: