### PR TITLE
release(patch): v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A textlint rule for checking allowed URIs in links and images of Markdown.🔥",
   "main": "build/textlint-rule-allowed-uris.js",
   "files": [


### PR DESCRIPTION
Bump `lumirlumir/npm-textlint-rule-allowed-uris` from v1.0.4 to v1.0.5 :tada: