### PR TITLE
build: simplify `build` script by removing unnecessary flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prepare": "husky",
     "publish-package": "npm publish",
     "prepublishOnly": "npm run build",
-    "build": "npx babel src -d build --no-comments --compact true --minified",
+    "build": "npx babel src -d build",
     "test": "concurrently \"npm:test:*\"",
     "test:tests": "npx mocha ./tests --inline-diffs true",
     "test:classes": "npx mocha ./tests/classes --inline-diffs true",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to simplify the build process by removing certain Babel options.

Build process simplification:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R34): Modified the `build` script to remove the `--no-comments`, `--compact true`, and `--minified` options from the Babel command.