### PR TITLE
chore: create `.gitattributes` for consistent EOL handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# https://git-scm.com/docs/gitattributes
+
+# Ensure consistent EOL(LF) for all files that Git considers text files.
+* text=auto eol=lf

--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -49,6 +49,8 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.eslintignore
   - source: ./.eslintrc.js
     dest: ./configs/.eslintrc.js
+  - source: ./.gitattributes
+    dest: ./configs/.gitattributes
   - source: ./.gitignore
     dest: ./configs/.gitignore
   - source: ./.markdownlint.json


### PR DESCRIPTION
This pull request includes changes to ensure consistent end-of-line (EOL) settings across text files and updates to the sync-client configuration to include the `.gitattributes` file. 

Changes to EOL settings:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R4): Added configuration to ensure consistent EOL (LF) for all text files.

Updates to sync-client configuration:

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R52-R53): Added `.gitattributes` to the list of files to be synchronized.