### PR TITLE
chore: add `packageManager` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "textlint-rule-allowed-uris",
   "version": "1.0.7",
+  "packageManager": "npm@10.9.2",
   "description": "A textlint rule for checking allowed URIs in links and images of Markdown.🔥",
   "main": "build/textlint-rule-allowed-uris.js",
   "files": [


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change specifies the package manager to be used for the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4): Added `"packageManager": "npm@10.9.2"` to ensure consistency in the development environment.