### PR TITLE
chore(*): add `provenance` to `publishConfig` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "bugs": {
     "url": "https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/issues"
   },
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "prepare": "husky",
     "publish-package": "npm publish",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds a `publishConfig` section to enable provenance when publishing the package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R31-R33): Added `publishConfig` with `provenance` set to true.