### PR TITLE
refactor(*): update module imports to use `node:` prefix for consistency

### DIFF
--- a/src/utils/getDefinitionNodeUriType.js
+++ b/src/utils/getDefinitionNodeUriType.js
@@ -1,4 +1,4 @@
-const url = require('url');
+const url = require('node:url');
 const c = require('ansi-colors');
 const mime = require('mime-types');
 const axios = require('axios');

--- a/tests/classes/UriList.test.js
+++ b/tests/classes/UriList.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const UriList = require('../../src/classes/UriList');
 
 /**

--- a/tests/textlint-rule-allowed-uris.test.js
+++ b/tests/textlint-rule-allowed-uris.test.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const TextLintTester = require('textlint-tester').default;
 const allowedUris = require('../src/textlint-rule-allowed-uris');
 const testCases = require('./textlint-rule-allowed-uris.data');

--- a/tests/utils/getDefinitionNodeUriType.test.js
+++ b/tests/utils/getDefinitionNodeUriType.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const testCases = require('./getDefinitionNodeUriType.data');
 const getDefinitionNodeUriType = require('../../src/utils/getDefinitionNodeUriType');
 

--- a/tests/utils/getUriList.test.js
+++ b/tests/utils/getUriList.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const testCases = require('./getUriList.data');
 const getUriList = require('../../src/utils/getUriList');
 


### PR DESCRIPTION
This pull request includes changes to update the way modules are imported in the codebase, specifically by using the `node:` prefix for built-in Node.js modules. This change aims to improve clarity and consistency in module imports.

Updates to module imports:

* [`src/utils/getDefinitionNodeUriType.js`](diffhunk://#diff-9c07b238e45a785203810889d94abae9a36233ef368a31737760c7823c53f16aL1-R1): Changed the import of the `url` module to use the `node:` prefix.
* [`tests/classes/UriList.test.js`](diffhunk://#diff-cd41077d9afeab05a191cbdbe1c8c0fcd90438244e03605495d8f33c8b6c0b65L1-R1): Changed the import of the `assert` module to use the `node:` prefix.
* [`tests/textlint-rule-allowed-uris.test.js`](diffhunk://#diff-89b20226c99b6337f60cfce86fa424eded9dcce3e51d2231af14c9ca52614ae1L1-R2): Changed the imports of the `fs` and `path` modules to use the `node:` prefix.
* [`tests/utils/getDefinitionNodeUriType.test.js`](diffhunk://#diff-d8443190744a22be3fffdc0fa18f35ddcc92a05bf8abbb8938241d34a85bbb05L1-R1): Changed the import of the `assert` module to use the `node:` prefix.
* [`tests/utils/getUriList.test.js`](diffhunk://#diff-e779cd142a4be7f29b798f050b66067259cf164fa5c2d2b591502e00a6fc2a33L1-R1): Changed the import of the `assert` module to use the `node:` prefix.