### PR TITLE
chore(*): add textlint configuration and integrate with lint-staged

### DIFF
--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -57,6 +57,8 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/.prettierignore
   - source: ./.prettierrc.js
     dest: ./configs/.prettierrc.js
+  - source: ./.textlintrc.js
+    dest: ./configs/.textlintrc.js
   - source: ./CODE_OF_CONDUCT.md
     dest: ./configs/CODE_OF_CONDUCT.md
   - source: ./LICENSE.md
@@ -69,3 +71,5 @@ lumirlumir/lumirlumir-configs:
     dest: ./configs/babel.config.js
   - source: ./eslint.config.mjs
     dest: ./configs/eslint.config.mjs
+  - source: ./lint-staged.config.js
+    dest: ./configs/lint-staged.config.js

--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rules: {
+    'allowed-uris': {
+      disallowed: {
+        links: [/^\.\//],
+      },
+    },
+  },
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,5 +4,5 @@ module.exports = {
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
   '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',
-  '*.md': 'npx markdownlint',
+  '*.md': ['npx markdownlint', 'npx textlint -f pretty-error'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "textlint-rule-allowed-uris",
       "version": "1.0.8",
       "license": "MIT",
+      "workspaces": [
+        "."
+      ],
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "axios": "^1.8.3",
@@ -11247,6 +11250,10 @@
       "engines": {
         "node": ">=18.14.0"
       }
+    },
+    "node_modules/textlint-rule-allowed-uris": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/textlint-tester": {
       "version": "14.5.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "textlint-rule-allowed-uris",
   "version": "1.0.8",
   "packageManager": "npm@10.9.2",
+  "workspaces": [
+    "."
+  ],
   "description": "A textlint rule for checking allowed URIs in links and images of Markdown.🔥",
   "main": "build/textlint-rule-allowed-uris.js",
   "files": [
@@ -46,6 +49,7 @@
     "lint:prettier": "npx prettier . --check",
     "lint:editorconfig": "npx editorconfig-checker -config .editorconfig-checker.json",
     "lint:markdownlint": "npx markdownlint **/*.md",
+    "lint:textlint": "npx textlint -f pretty-error **/*.md",
     "textlint-pretty": "npx textlint tests/textlint-rule-allowed-uris.data.md --rulesdir ./src -f pretty-error",
     "textlint-stylish": "npx textlint tests/textlint-rule-allowed-uris.data.md --rulesdir ./src -f stylish",
     "textlint-json": "npx textlint tests/textlint-rule-allowed-uris.data.md --rulesdir ./src -f json"


### PR DESCRIPTION
This pull request includes several changes to the configuration files and the addition of new linting rules. The most important changes involve adding new source files to the sync configuration, introducing a new textlint rule, and updating the lint-staged configuration.

Configuration updates:

* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R60-R61): Added new source files `./.textlintrc.js` and `./lint-staged.config.js` to the sync configuration. [[1]](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R60-R61) [[2]](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1R74-R75)

Linting improvements:

* [`.textlintrc.js`](diffhunk://#diff-b6512489def90a2f455833dc056c80f0fc91accd990eee2e3e7cf718ce7b76edR1-R9): Introduced a new textlint rule to disallow certain URIs in links.
* [`lint-staged.config.js`](diffhunk://#diff-29c15f0b5d8d1144bd22153c302cde16c2de092d65b122a618cbdb3023336346L7-R7): Updated the configuration to include `textlint` for Markdown files.

Package configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5-R7): Added workspaces configuration and a new script for running `textlint`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R5-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R52)