### PR TITLE
chore(release): bump package versions from `v1.0.8` to `v1.0.9` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "workspaces": [
         "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "packageManager": "npm@10.9.2",
   "workspaces": [
     "."


### PR DESCRIPTION
## Release Information: `v1.0.9`

New release of `lumirlumir/npm-textlint-rule-allowed-uris` has arrived! :tada:

This PR bumps the package versions from `v1.0.8` to `v1.0.9` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/actions/runs/13927306027) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-textlint-rule-allowed-uris` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | f11ce22       |
| Old Version | `v1.0.8`  |
| New Version | `v1.0.9`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :toolbox: Chores
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/167
* chore(*): add `provenance` to `publishConfig` in `package.json` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/169
* chore(sync-server): update `publish.yml` and `.prettierignore` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/171
* chore(sync-server): update `.editorconfig` `max_line_length` to `100000` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/181
* chore(sync-server): update `.markdownlint.json` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/186
* chore(*): install `textlint` as deps-dev and delete unnecessary files by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/190
* chore(*): drop `mocha` and replace it with node built-in test runner by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/192
* chore(*): create `CONTRIBUTING.md` and update ESLint config file by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/194
* chore(*): add textlint configuration and integrate with lint-staged by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/197
### :arrows_counterclockwise: Continuous Integrations
* ci(sync-server): add permissions to read contents in `lint.yml` and `test.yml` workflows by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/179
* ci(sync-server): add permissions to `pull-request.yml` and `sync-client.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/180
* ci(*): drop `bump.yml` and create `version-multirepo.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/198
* ci(*): create `release.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/199
### :memo: Documentation
* docs(*): create `SECURITY.md` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/193
* docs(*): update `README.md` and `config.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/195
### :recycle: Code Refactoring
* refactor(*): update module imports to use `node:` prefix for consistency by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/173
* refactor(*): create `src/types.js` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/174
* refactor(*): rename `src/types.js` to `src/types/index.js` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/175
* refactor(*): restructure `theme` utilities and update usage in files by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/176
* refactor(*): rename and refactor `UriTypes` class by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/177
* refactor(*): restructure directories and update comments by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/191
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint from 9.20.1 to 9.21.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/165
* chore(deps-dev): bump prettier from 3.5.1 to 3.5.2 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/166
* chore(deps): bump axios from 1.7.9 to 1.8.1 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/168
* chore(deps): bump undici from 6.19.7 to 6.21.1 in the npm_and_yarn group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/170
* chore(deps-dev): bump prettier from 3.5.2 to 3.5.3 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/172
* chore(deps-dev): bump eslint from 9.21.0 to 9.22.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/182
* chore(deps): bump axios from 1.8.1 to 1.8.2 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/183
* chore(deps-dev): bump @babel/core from 7.26.9 to 7.26.10 in the babel group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/184
* chore(deps-dev): bump textlint-tester from 14.4.2 to 14.5.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/185
* chore(deps-dev): bump eslint-config-bananass from 0.0.5 to 0.0.6 in the bananass group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/187
* chore(deps): bump axios from 1.8.2 to 1.8.3 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/188
* chore(deps-dev): bump lint-staged from 15.4.3 to 15.5.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/189


**Full Changelog**: https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/compare/v1.0.8...v1.0.9