### PR TITLE
refactor(*): drop `ansi-colors` dependency and update theme functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "."
       ],
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "axios": "^1.8.3",
         "cheerio": "^1.0.0",
         "mime-types": "^3.0.1"
@@ -3389,15 +3388,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "textlint-tester": "^14.6.0"
   },
   "dependencies": {
-    "ansi-colors": "^4.1.3",
     "axios": "^1.8.3",
     "cheerio": "^1.0.0",
     "mime-types": "^3.0.1"

--- a/src/textlint-rule-allowed-uris.js
+++ b/src/textlint-rule-allowed-uris.js
@@ -7,7 +7,7 @@
 // Require
 // --------------------------------------------------------------------------------
 
-const { error, highlight, strikethrough } = require('./utils/theme');
+const { error, strikethrough } = require('./utils/theme');
 const getUriTypes = require('./utils/get-uri-types');
 
 // --------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ const reporter = async ({ report, locator, RuleError }, options, node) => {
         report(
           node,
           new RuleError(
-            `${error(`${key}.${type}s`)}\n${error('-')} problem: '${strikethrough(uri)}'\n${error('-')} ${key} regular expressions: '${highlight(regexes[key][`${type}s`].join(' or '))}'`,
+            `${error(`${key}.${type}s`)}\n${error('-')} problem: '${strikethrough(uri)}'\n${error('-')} ${key} regular expressions: '${regexes[key][`${type}s`].join(' or ')}'`,
             {
               padding: locator.at(0),
             },

--- a/src/utils/theme/theme.js
+++ b/src/utils/theme/theme.js
@@ -3,18 +3,10 @@
  */
 
 // --------------------------------------------------------------------------------
-// Require
-// --------------------------------------------------------------------------------
-
-const c = require('ansi-colors');
-
-// --------------------------------------------------------------------------------
 // Exports
 // --------------------------------------------------------------------------------
 
-/** Console error theme. */
-module.exports.error = c.red.bold;
-/** Console highlight theme. */
-module.exports.highlight = c.white.bold;
-/** Console strikethrough theme. */
-module.exports.strikethrough = c.white.bold.strikethrough;
+/** Console error theme. @param {string} str */
+module.exports.error = str => `\u001b[31m${str}\u001b[0m`;
+/** Console strikethrough theme. @param {string} str */
+module.exports.strikethrough = str => `\u001b[9m${str}\u001b[0m`;


### PR DESCRIPTION
This pull request includes several changes aimed at removing the `ansi-colors` dependency and simplifying the theme utility functions. The most important changes include updating the `package.json` file, modifying the theme utility functions, and adjusting the usage of these functions in the codebase.

Dependency removal and updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L88): Removed the `ansi-colors` dependency.

Theme utility function simplification:

* [`src/utils/theme/theme.js`](diffhunk://#diff-a64b8913370277e64be5780ab872f96593fd78d80161b8afde3393f0ece0a521L5-R12): Replaced the use of `ansi-colors` with custom functions for `error` and `strikethrough` themes.

Code adjustments for theme changes:

* [`src/textlint-rule-allowed-uris.js`](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L10-R10): Removed the `highlight` import from `theme` and adjusted the `reporter` function to use the updated `error` and `strikethrough` functions. [[1]](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L10-R10) [[2]](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L70-R70)