### PR TITLE
refactor(*): drop `axios` and replace it with `fetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "."
       ],
       "dependencies": {
-        "axios": "^1.8.3",
         "cheerio": "^1.0.0",
         "mime-types": "^3.0.1"
       },
@@ -3648,12 +3647,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3678,17 +3671,6 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -4410,18 +4392,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -4756,15 +4726,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -6225,26 +6186,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6275,41 +6216,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/format": {
@@ -9931,12 +9837,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "textlint-tester": "^14.6.0"
   },
   "dependencies": {
-    "axios": "^1.8.3",
     "cheerio": "^1.0.0",
     "mime-types": "^3.0.1"
   }

--- a/src/utils/get-definition-node-uri-type/get-definition-node-uri-type.js
+++ b/src/utils/get-definition-node-uri-type/get-definition-node-uri-type.js
@@ -7,10 +7,7 @@
 // --------------------------------------------------------------------------------
 
 const url = require('node:url');
-
 const mime = require('mime-types');
-const axios = require('axios');
-
 const { error } = require('../theme');
 
 // --------------------------------------------------------------------------------
@@ -26,11 +23,11 @@ const { error } = require('../theme');
 const getMimeType = async uri => {
   try {
     // fetch succeeded. (i.e. Remote URI links)
-    // @ts-expect-error -- TODO
-    return (await axios.head(uri)).headers['content-type'];
+    const response = await fetch(uri, { method: 'HEAD' });
+    return response.headers.get('content-type');
   } catch (err) {
     // fetch failed. (Internet connection)
-    if (err.code === 'ENOTFOUND')
+    if (err?.cause?.code === 'ENOTFOUND')
       throw new Error(
         error(
           'The linting process includes an HTTP request, so an internet connection is required',

--- a/src/utils/get-uri-types/get-uri-types.js
+++ b/src/utils/get-uri-types/get-uri-types.js
@@ -61,7 +61,6 @@ const getUriTypesHtml = ({ value }) => {
   const $ = cheerio.load(value);
 
   $('a, img').each((_, elem) => {
-    // @ts-ignore -- TODO
     const tag = $(elem).prop('tagName').toLowerCase();
 
     if (tag === 'a') {

--- a/src/utils/get-uri-types/get-uri-types.js
+++ b/src/utils/get-uri-types/get-uri-types.js
@@ -86,7 +86,6 @@ const getUriTypesHtml = ({ value }) => {
 /**
  * Retrieves the URI and creates an instance of `UriTypes` from a given `node`.
  * @param {TxtLinkNode | TxtImageNode | TxtDefinitionNode | TxtHtmlNode} node The node from which to retrieve the URI.
- * @throws {TypeError} Throws an `TypeError` if `node.type` is not one of `Link`, `Image`, `Definition`, or `Html`.
  * @async
  */
 module.exports = async function getUriTypes(node) {
@@ -99,9 +98,7 @@ module.exports = async function getUriTypes(node) {
       return getUriTypesDefinition(node);
     case 'Html':
       return getUriTypesHtml(node);
-    default:
-      throw new TypeError(
-        'Invalid `node.type` parameter. It should be `Link`, `Image`, `Definition`, or `Html`',
-      );
+    default: // Unreachable
+      return undefined;
   }
 };

--- a/src/utils/get-uri-types/get-uri-types.test.js
+++ b/src/utils/get-uri-types/get-uri-types.test.js
@@ -6,7 +6,7 @@
 // Require
 // --------------------------------------------------------------------------------
 
-const { deepStrictEqual, rejects } = require('node:assert');
+const { deepStrictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 
 const getUriTypes = require('./get-uri-types');
@@ -606,7 +606,7 @@ describe('get-uri-types.js', () => {
   });
 
   describe('Invalid node type', () => {
-    it('Invalid node type should throw an error', async () => {
+    it('Invalid node type should return `undefined`', async () => {
       const actual = {
         type: 'Document',
         raw: '',
@@ -624,9 +624,7 @@ describe('get-uri-types.js', () => {
         children: [],
       };
 
-      await rejects(async () => {
-        await getUriTypes(actual);
-      });
+      deepStrictEqual(await getUriTypes(actual), undefined);
     });
   });
 });


### PR DESCRIPTION
This pull request includes several changes to improve the codebase by removing the `axios` dependency, updating the `get-definition-node-uri-type` function, and modifying the error handling and testing logic in the `get-uri-types` module.

### Dependency removal:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L88): Removed `axios` from dependencies.
* [`src/utils/get-definition-node-uri-type/get-definition-node-uri-type.js`](diffhunk://#diff-7facb9d42bcc13857fefafc7c89f3bc71f7aea27042c5251c4d534b101628c8eL10-L13): Removed `axios` import.

### Function updates:
* [`src/utils/get-definition-node-uri-type/get-definition-node-uri-type.js`](diffhunk://#diff-7facb9d42bcc13857fefafc7c89f3bc71f7aea27042c5251c4d534b101628c8eL29-R30): Replaced `axios.head` with `fetch` for fetching MIME types and updated error handling to use optional chaining.

### Error handling improvements:
* [`src/utils/get-uri-types/get-uri-types.js`](diffhunk://#diff-ae0ca24cd5da9be0ab68a39c227181c366ccf801a2e742976dbca35867112bccL103-R102): Updated default case in `getUriTypes` function to return `undefined` instead of throwing a `TypeError`.

### Testing adjustments:
* [`src/utils/get-uri-types/get-uri-types.test.js`](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL609-R609): Modified test for invalid node type to check for `undefined` return value instead of expecting an error. [[1]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL609-R609) [[2]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL627-R627)