### PR TITLE
chore(release): bump package versions from `v1.0.9` to `v1.1.0` (`minor`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "packageManager": "npm@10.9.2",
   "workspaces": [
     "."


### PR DESCRIPTION
## Release Information: `v1.1.0`

New release of `lumirlumir/npm-textlint-rule-allowed-uris` has arrived! :tada:

This PR bumps the package versions from `v1.0.9` to `v1.1.0` (`minor`).

See [Actions](https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/actions/runs/14419706335) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-textlint-rule-allowed-uris` |
| SEMVER      | `minor`     |
| Pre ID      | `canary`      |
| Short SHA   | ed6cfe5       |
| Old Version | `v1.0.9`  |
| New Version | `v1.1.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :sparkles: Features
* feat(*): refactor and support types by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/211
### :toolbox: Chores
* chore(*): add Open Collective funding source by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/201
* chore(sync-server): update root level config files and fix typos by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/206
* chore(*): rename root level config files to `mjs` and `cjs` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/210
### :recycle: Code Refactoring
* refactor(*): drop `ansi-colors` dependency and update theme functions by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/212
* refactor(*): drop `axios` and replace it with `fetch` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/217
### :test_tube: Tests
* test(*): remove `data.js` files and move them to corresponding `test.js` files by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/216
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint from 9.22.0 to 9.23.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/203
* chore(deps-dev): bump @babel/cli from 7.26.4 to 7.27.0 in the babel group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/204
* chore(deps): bump mime-types from 2.1.35 to 3.0.1 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/205
* chore(deps-dev): bump textlint from 14.5.0 to 14.6.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/207
* chore(deps-dev): bump textlint-tester from 14.5.0 to 14.6.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/208
* chore(deps-dev): bump @types/node from 22.13.17 to 22.14.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/213
* chore(deps-dev): bump eslint-config-bananass from 0.0.6 to 0.0.7 in the bananass group across 1 directory by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/214
* chore(deps-dev): bump eslint from 9.23.0 to 9.24.0 by @dependabot in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/215


**Full Changelog**: https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/compare/v1.0.9...v1.1.0