### PR TITLE
test(*): simplify describe blocks in test files

### DIFF
--- a/src/utils/get-definition-node-uri-type/get-definition-node-uri-type.test.js
+++ b/src/utils/get-definition-node-uri-type/get-definition-node-uri-type.test.js
@@ -15,7 +15,7 @@ const getDefinitionNodeUriType = require('./get-definition-node-uri-type');
 // Test
 // --------------------------------------------------------------------------------
 
-describe('get-definition-node-uri-type.js', () => {
+describe('get-definition-node-uri-type', () => {
   describe('comment', () => {
     it("The empty `''` character should be a `comment`", async () => {
       const actual = '';

--- a/src/utils/get-uri-types/get-uri-types.test.js
+++ b/src/utils/get-uri-types/get-uri-types.test.js
@@ -15,7 +15,7 @@ const getUriTypes = require('./get-uri-types');
 // Test
 // --------------------------------------------------------------------------------
 
-describe('get-uri-types.js', () => {
+describe('get-uri-types', () => {
   describe('Link', () => {
     describe('`Link` node', () => {
       it('A `Link` node starting with `https://` should have type `link` in `UriType`', async () => {

--- a/src/utils/uri-types/uri-types.test.js
+++ b/src/utils/uri-types/uri-types.test.js
@@ -15,7 +15,7 @@ const UriTypes = require('./uri-types');
 // Test
 // --------------------------------------------------------------------------------
 
-describe('uri-types.js', () => {
+describe('uri-types', () => {
   // deepStrictEqual
   it('Method: new UriTypes()', () => {
     deepStrictEqual([], new UriTypes().uriTypes);


### PR DESCRIPTION
This pull request includes minor changes to standardize test descriptions by removing the `.js` file extension from the `describe` blocks in test files.

* Standardizing test descriptions:
  * Updated the `describe` block in `get-definition-node-uri-type.test.js` to remove the `.js` file extension.
  * Updated the `describe` block in `get-uri-types.test.js` to remove the `.js` file extension.
  * Updated the `describe` block in `uri-types.test.js` to remove the `.js` file extension.