### PR TITLE
refactor(*): migrate type declarations to use `@import` syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "prettier": "^3.6.0",
         "prettier-config-bananass": "^0.1.2",
         "textlint": "^14.7.2",
-        "textlint-tester": "^14.7.2"
+        "textlint-tester": "^14.7.2",
+        "typescript": "^5.8.3"
       },
       "peerDependencies": {
         "textlint": "^14.0.4"
@@ -11448,7 +11449,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "prettier": "^3.6.0",
     "prettier-config-bananass": "^0.1.2",
     "textlint": "^14.7.2",
-    "textlint-tester": "^14.7.2"
+    "textlint-tester": "^14.7.2",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "cheerio": "^1.1.0",

--- a/src/textlint-rule-allowed-uris.js
+++ b/src/textlint-rule-allowed-uris.js
@@ -15,12 +15,9 @@ const getUriTypes = require('./utils/get-uri-types');
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import('@textlint/types').TextlintRuleContext} TextlintRuleContext
- * @typedef {import('@textlint/ast-node-types').TxtLinkNode} TxtLinkNode
- * @typedef {import('@textlint/ast-node-types').TxtImageNode} TxtImageNode
- * @typedef {import('@textlint/ast-node-types').TxtDefinitionNode} TxtDefinitionNode
- * @typedef {import('@textlint/ast-node-types').TxtHtmlNode} TxtHtmlNode
- * @typedef {import('./types').Options} Options
+ * @import { TextlintRuleContext } from '@textlint/types';
+ * @import { TxtLinkNode, TxtImageNode, TxtDefinitionNode, TxtHtmlNode } from '@textlint/ast-node-types';
+ * @import { Options } from './types';
  */
 
 // --------------------------------------------------------------------------------

--- a/src/utils/get-uri-types/get-uri-types.js
+++ b/src/utils/get-uri-types/get-uri-types.js
@@ -16,10 +16,7 @@ const getDefinitionNodeUriType = require('../get-definition-node-uri-type');
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import('@textlint/ast-node-types').TxtLinkNode} TxtLinkNode
- * @typedef {import('@textlint/ast-node-types').TxtImageNode} TxtImageNode
- * @typedef {import('@textlint/ast-node-types').TxtDefinitionNode} TxtDefinitionNode
- * @typedef {import('@textlint/ast-node-types').TxtHtmlNode} TxtHtmlNode
+ * @import { TxtLinkNode, TxtImageNode, TxtDefinitionNode, TxtHtmlNode } from '@textlint/ast-node-types';
  */
 
 // --------------------------------------------------------------------------------

--- a/src/utils/uri-types/uri-types.js
+++ b/src/utils/uri-types/uri-types.js
@@ -9,7 +9,7 @@
 // --------------------------------------------------------------------------------
 
 /**
- * @typedef {import('../../types/index.js').UriType} UriType
+ * @import { UriType } from '../../types';
  */
 
 // --------------------------------------------------------------------------------
@@ -18,7 +18,6 @@
 
 /**
  * Manage an array of `UriType` objects.
- *
  * @example
  * [
  *   // ...
@@ -47,7 +46,6 @@ class UriTypes {
 
   /**
    * Pushes a new `UriType` object.
-   *
    * @param {UriType} uriType The `UriType` object.
    * @returns {this} The current instance of `UriTypes` to allow for method chaining.
    */
@@ -74,7 +72,6 @@ class UriTypes {
 
   /**
    * Returns an array of `UriType` objects.
-   *
    * @example
    * [
    *   // ...


### PR DESCRIPTION
This pull request includes updates to dependencies and refactors type definitions across several files to improve code consistency and maintainability. The most important changes involve adding TypeScript as a dependency and replacing JSDoc `@typedef` annotations with ES6 `import` statements for type definitions.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L86-R87): Added TypeScript (`"typescript": "^5.8.3"`) as a new development dependency.

### Type Definition Refactoring:
* [`src/textlint-rule-allowed-uris.js`](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L18-R20): Replaced JSDoc `@typedef` annotations with ES6 `import` statements for types such as `TextlintRuleContext` and `TxtLinkNode`.
* [`src/utils/get-uri-types/get-uri-types.js`](diffhunk://#diff-ae0ca24cd5da9be0ab68a39c227181c366ccf801a2e742976dbca35867112bccL19-R19): Updated type definitions to use ES6 `import` statements for `TxtLinkNode`, `TxtImageNode`, `TxtDefinitionNode`, and `TxtHtmlNode`.
* [`src/utils/uri-types/uri-types.js`](diffhunk://#diff-26209a01a5e08ece866bd3c46294706b8d9a196231a822b0cacd8cdb9156a9feL12-R12): Refactored type definitions to use ES6 `import` for `UriType`.

### Minor Documentation Cleanup:
* [`src/utils/uri-types/uri-types.js`](diffhunk://#diff-26209a01a5e08ece866bd3c46294706b8d9a196231a822b0cacd8cdb9156a9feL21): Removed unnecessary blank lines in JSDoc comments for methods in the `UriTypes` class. [[1]](diffhunk://#diff-26209a01a5e08ece866bd3c46294706b8d9a196231a822b0cacd8cdb9156a9feL21) [[2]](diffhunk://#diff-26209a01a5e08ece866bd3c46294706b8d9a196231a822b0cacd8cdb9156a9feL50) [[3]](diffhunk://#diff-26209a01a5e08ece866bd3c46294706b8d9a196231a822b0cacd8cdb9156a9feL77)