### PR TITLE
refactor(*): improve structure and clarity of URI type retrieval functions

### DIFF
--- a/src/utils/get-uri-types/get-uri-types.js
+++ b/src/utils/get-uri-types/get-uri-types.js
@@ -26,32 +26,35 @@ const getDefinitionNodeUriType = require('../get-definition-node-uri-type');
 /**
  * Retrieves URI from a given `Link` node and returns an instance of `UriTypes`.
  * @param {TxtLinkNode} node `Link` type node.
+ * @return {UriTypes}
  */
 const getUriTypesLink = ({ url }) => new UriTypes().push({ uri: url, type: 'link' });
 
 /**
  * Retrieves URI from a given `Image` node and returns an instance of `UriTypes`.
  * @param {TxtImageNode} node `Image` type node.
+ * @return {UriTypes}
  */
 const getUriTypesImage = ({ url }) => new UriTypes().push({ uri: url, type: 'image' });
 
 /**
  * Retrieves URI from a given `Definition` node and returns an instance of `UriTypes`.
  * @param {TxtDefinitionNode} node `Definition` type node.
+ * @return {Promise<UriTypes>}
  * @async
  */
 const getUriTypesDefinition = async ({ url }) => {
   const type = await getDefinitionNodeUriType(url);
 
-  return ['link', 'image'].includes(type)
-    ? // @ts-ignore -- TODO
-      new UriTypes().push({ uri: url, type })
+  return type === 'link' || type === 'image'
+    ? new UriTypes().push({ uri: url, type })
     : new UriTypes();
 };
 
 /**
  * Parses the HTML content of the given node and retrieves all the `<a>` and `<img>` tag's URIs.
  * @param {TxtHtmlNode} node `Html` type node.
+ * @return {UriTypes}
  */
 const getUriTypesHtml = ({ value }) => {
   const uriTypes = new UriTypes();
@@ -80,22 +83,9 @@ const getUriTypesHtml = ({ value }) => {
 // Exports
 // --------------------------------------------------------------------------------
 
-/**
- * Retrieves the URI and creates an instance of `UriTypes` from a given `node`.
- * @param {TxtLinkNode | TxtImageNode | TxtDefinitionNode | TxtHtmlNode} node The node from which to retrieve the URI.
- * @async
- */
-module.exports = async function getUriTypes(node) {
-  switch (node.type) {
-    case 'Link':
-      return getUriTypesLink(node);
-    case 'Image':
-      return getUriTypesImage(node);
-    case 'Definition':
-      return getUriTypesDefinition(node);
-    case 'Html':
-      return getUriTypesHtml(node);
-    default: // Unreachable
-      return undefined;
-  }
+module.exports = {
+  getUriTypesLink,
+  getUriTypesImage,
+  getUriTypesDefinition,
+  getUriTypesHtml,
 };

--- a/src/utils/get-uri-types/get-uri-types.test.js
+++ b/src/utils/get-uri-types/get-uri-types.test.js
@@ -9,7 +9,12 @@
 const { deepStrictEqual } = require('node:assert');
 const { describe, it } = require('node:test');
 
-const getUriTypes = require('./get-uri-types');
+const {
+  getUriTypesLink,
+  getUriTypesImage,
+  getUriTypesDefinition,
+  getUriTypesHtml,
+} = require('./get-uri-types');
 
 // --------------------------------------------------------------------------------
 // Test
@@ -61,7 +66,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
 
       it('A `Link` node starting with `https://` and with a title should have type `link` in `UriType`', async () => {
@@ -107,7 +112,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
 
       it('A `Link` node starting with `mailto:` should have type `link` in `UriType`', async () => {
@@ -153,7 +158,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
 
       it('A `link` node with empty URL should have type `link` in `UriType`', async () => {
@@ -199,7 +204,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
 
       it('A `link` node with only `#` hash fragment should have type `link` in `UriType`', async () => {
@@ -245,7 +250,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
 
       it('A `link` node whose URL is a relative path should have type `link` in `UriType`', async () => {
@@ -291,7 +296,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesLink(actual).uriTypes, expected);
       });
     });
 
@@ -323,7 +328,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual((await getUriTypesDefinition(actual)).uriTypes, expected);
       });
     });
 
@@ -352,7 +357,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual((await getUriTypesHtml(actual)).uriTypes, expected);
       });
     });
   });
@@ -385,7 +390,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesImage(actual).uriTypes, expected);
       });
     });
 
@@ -417,7 +422,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual((await getUriTypesDefinition(actual)).uriTypes, expected);
       });
     });
 
@@ -446,7 +451,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesHtml(actual).uriTypes, expected);
       });
 
       it('Nested `Html` node with `div` and `img` tags should have type `image` in `UriType` - 1', async () => {
@@ -478,7 +483,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesHtml(actual).uriTypes, expected);
       });
 
       it('Nested `Html` node with `div` and `img` tags should have type `image` in `UriType` - 2', async () => {
@@ -510,7 +515,7 @@ describe('get-uri-types', () => {
           },
         ];
 
-        deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+        deepStrictEqual(getUriTypesHtml(actual).uriTypes, expected);
       });
     });
   });
@@ -549,7 +554,7 @@ describe('get-uri-types', () => {
         },
       ];
 
-      deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+      deepStrictEqual(getUriTypesHtml(actual).uriTypes, expected);
     });
   });
 
@@ -576,7 +581,7 @@ describe('get-uri-types', () => {
       };
       const expected = [];
 
-      deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
+      deepStrictEqual((await getUriTypesDefinition(actual)).uriTypes, expected);
     });
 
     it('[comment]: <> (This behaves like a comment)', async () => {
@@ -601,30 +606,7 @@ describe('get-uri-types', () => {
       };
       const expected = [];
 
-      deepStrictEqual((await getUriTypes(actual)).uriTypes, expected);
-    });
-  });
-
-  describe('Invalid node type', () => {
-    it('Invalid node type should return `undefined`', async () => {
-      const actual = {
-        type: 'Document',
-        raw: '',
-        range: [0, 0],
-        loc: {
-          start: {
-            line: 1,
-            column: 0,
-          },
-          end: {
-            line: 1,
-            column: 0,
-          },
-        },
-        children: [],
-      };
-
-      deepStrictEqual(await getUriTypes(actual), undefined);
+      deepStrictEqual((await getUriTypesDefinition(actual)).uriTypes, expected);
     });
   });
 });


### PR DESCRIPTION
This pull request refactors the `textlint-rule-allowed-uris` rule to improve modularity and maintainability by splitting the URI type handlers into separate functions. It also updates related tests to align with the new structure.

### Refactoring of URI type handling:

* In `src/textlint-rule-allowed-uris.js`, replaced the single `getUriTypes` function with modularized functions (`getUriTypesLink`, `getUriTypesImage`, `getUriTypesDefinition`, and `getUriTypesHtml`) for handling different node types. Updated the rule's entry point to utilize these modularized functions. [[1]](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L2-R16) [[2]](diffhunk://#diff-7da72e1e0d5c49a43b94f9d928d3157918c0bdcc3121c5ed14e0bc459b3f26f9L20-R102)

* In `src/utils/get-uri-types/get-uri-types.js`, removed the monolithic `getUriTypes` function and exported the new modularized functions for retrieving URIs based on node types. [[1]](diffhunk://#diff-ae0ca24cd5da9be0ab68a39c227181c366ccf801a2e742976dbca35867112bccR29-R57) [[2]](diffhunk://#diff-ae0ca24cd5da9be0ab68a39c227181c366ccf801a2e742976dbca35867112bccL83-R90)

### Updates to tests:

* In `src/utils/get-uri-types/get-uri-types.test.js`, updated test cases to directly test the new modularized functions instead of the removed `getUriTypes` function. This ensures the tests are aligned with the refactored code. [[1]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL12-R17) [[2]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL64-R69) [[3]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL326-R331) [[4]](diffhunk://#diff-4e8cad35eb168c20ef479b5e7b8262cc6c5449dd35828f86afbbdc407d73037bL604-R609)

These changes improve code readability, make the codebase easier to maintain, and ensure that each function has a single responsibility.