### PR TITLE
chore(release): bump package versions from `v1.1.1` to `v2.0.0` (`major`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "workspaces": [
         "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
## Release Information: `v2.0.0`

New release of `lumirlumir/npm-textlint-rule-allowed-uris` has arrived! :tada:

This PR bumps the package versions from `v1.1.1` to `v2.0.0` (`major`).

See [Actions](https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/actions/runs/16551356197) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-textlint-rule-allowed-uris` |
| SEMVER      | `major`     |
| Pre ID      | `canary`      |
| Short SHA   | 90ae620       |
| Old Version | `v1.1.1`  |
| New Version | `v2.0.0`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :boom: BREAKING CHANGES
* refactor(*)!: migrate to ESM by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/301
* feat(*)!: drop async logic and add `checkUnusedDefinitions` option by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/305
### :sparkles: Features
* feat(*): support `textlint` v15 by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/306
### :bug: Bug Fixes
* fix(*): incorrect error location and refactor by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/304
### :toolbox: Chores
* chore(sync-server): update `dependabot.yml` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/280
* chore(*): move `FUNDING.yml` to `.github` repository by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/290
### :memo: Documentation
* docs(*): remove `PULL_REQUEST_TEMPLATE.md` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/293
* docs(*): update `README.md` by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/307
### :recycle: Code Refactoring
* refactor(*): migrate type declarations to use `@import` syntax by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/276
* refactor(*): improve structure and clarity of URI type retrieval functions by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/296
* refactor(*): simplify and cleanup logics by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/303
### :arrow_up: Dependency Updates
* chore(deps): bump cheerio from 1.0.0 to 1.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/266
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/265
* chore(deps-dev): bump @types/node from 22.15.29 to 24.0.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/269
* chore(deps-dev): bump @types/node from 24.0.0 to 24.0.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/270
* chore(deps-dev): bump lint-staged from 16.1.0 to 16.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/271
* chore(deps-dev): bump eslint from 9.28.0 to 9.29.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/272
* chore(deps-dev): bump concurrently from 9.1.2 to 9.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/274
* chore(deps-dev): bump prettier from 3.5.3 to 3.6.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/275
* chore(deps-dev): bump @types/node from 24.0.1 to 24.0.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/277
* chore(deps-dev): bump prettier from 3.6.0 to 3.6.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/278
* chore(deps-dev): bump @babel/core from 7.27.4 to 7.27.7 in the babel group across 1 directory by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/279
* chore(deps-dev): bump eslint from 9.29.0 to 9.30.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/282
* chore(deps-dev): bump @types/node from 24.0.4 to 24.0.7 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/281
* chore(deps-dev): bump prettier from 3.6.1 to 3.6.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/283
* chore(deps-dev): bump eslint from 9.30.0 to 9.30.1 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/286
* chore(deps-dev): bump @types/node from 24.0.7 to 24.0.10 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/285
* chore(deps-dev): bump the babel group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/287
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/289
* chore(deps-dev): bump @types/node from 24.0.10 to 24.0.12 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/288
* chore(deps-dev): bump eslint from 9.30.1 to 9.31.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/292
* chore(deps-dev): bump editorconfig-checker from 6.0.1 to 6.1.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/295
* chore(deps): bump cheerio from 1.1.0 to 1.1.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/299
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/302


**Full Changelog**: https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/compare/v1.1.1...v2.0.0