### PR TITLE
fix(*): add `package.json` export to module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ".": {
       "types": "./build/textlint-rule-allowed-uris.d.ts",
       "default": "./src/textlint-rule-allowed-uris.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "types": "build/textlint-rule-allowed-uris.d.ts",
   "typesVersions": {


### PR DESCRIPTION
This pull request makes a small change to the `package.json` file to include a self-referential entry for the package itself. This change adds `"./package.json": "./package.json"` to the exports field.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R16): Added a self-referential entry for `"./package.json"` in the exports field.