### PR TITLE
chore(release): bump package versions from `v2.0.0` to `v2.0.1` (`patch`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textlint-rule-allowed-uris",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "workspaces": [
         "."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-allowed-uris",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "packageManager": "npm@10.9.2",
   "workspaces": [


### PR DESCRIPTION
## Release Information: `v2.0.1`

New release of `lumirlumir/npm-textlint-rule-allowed-uris` has arrived! :tada:

This PR bumps the package versions from `v2.0.0` to `v2.0.1` (`patch`).

See [Actions](https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/actions/runs/16824078121) for more details.

| Info        | Value                      |
| ----------- | -------------------------- |
| Repository  | `lumirlumir/npm-textlint-rule-allowed-uris` |
| SEMVER      | `patch`     |
| Pre ID      | `canary`      |
| Short SHA   | 62524b8       |
| Old Version | `v2.0.0`  |
| New Version | `v2.0.1`  |

<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### :bug: Bug Fixes
* fix(*): add `package.json` export to module exports by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/310
### :toolbox: Chores
* chore(*): remove `ISSUE_TEMPLATE` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/311
* chore(*): remove `config.yml` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/312
### :memo: Documentation
* docs(*): remove `CODE_OF_CONDUCT.md` and `SECURITY.md` in favor of centralized template by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/314
### :recycle: Code Refactoring
* refactor(*): migrate to `parse5` to reduce dependency by @lumirlumir in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/318
### :arrow_up: Dependency Updates
* chore(deps-dev): bump eslint from 9.31.0 to 9.32.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/309
* chore(deps-dev): bump typescript from 5.8.3 to 5.9.2 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/313
* chore(deps-dev): bump lint-staged from 16.1.2 to 16.1.4 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/316
* chore(deps-dev): bump the bananass group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/315
* chore(deps-dev): bump @types/node from 24.0.12 to 24.2.0 by @dependabot[bot] in https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/pull/317


**Full Changelog**: https://github.com/lumirlumir/npm-textlint-rule-allowed-uris/compare/v2.0.0...v2.0.1