### PR TITLE
docs(*): update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A textlint rule for checking **allowed or disallowed URIs** in ***links*** and *
 
 You can use any ***link*** or ***image*** formats which are supported by Markdown. (Even **HTML tags** are available!)
 
-- [Click to see detailed Markdown examples](/src/textlint-rule-allowed-uris.md). Look at **raw** code. these all types are considered.
+- [Click to see detailed Markdown examples](/src/textlint-rule-allowed-uris.md#links). Look at **raw** code. these all types are considered.
 
 - You can also check out the [AST Tree of the above examples](https://textlint.org/astexplorer/#/snippet/woXCqHBhcnNlcklEwrh0ZXh0bGludDptxINrZG93bi10by1hc3TCqMSFdHTEkGdzwoHEisSMxI7EkMSSxJRyxJbEmMSaxJzEnsSgw4DCqHbEhnNpb27EqMSqxI3Ej8SRxJPElcSXxJnEm8SdxJ90wqYxNS4yLjHCqGZpbGVuYW1lwrBzb3VyY2UudW5kZcWUbmVkwqRjb8Wmw5oJwoQ8IS0tIMSvxLHEmcWCdC1kaXNhYsWWIMW1PiDFs8W1IGVzxbvFvcW_xoHGg8aFCgojIyBMxJBrc8aTxojFtsW4xYbEmmF1xJzFgmstcmF3xoQtPsaTaMSkcHM6Ly93xrYuZ29vZ8WWLsWtbcaTxIzFmXDFlkBnxJTFlca-b8eACsadxbfFhcSyxJ7Go2_GpS1ixqhja2V0xqvGrceNxq90xrHGs8a1xrfGuca7xr3Gv8eePMeCbceEZceGx4hsx4ptx6rFtMaex5DFh8SQxYJlx53Gk1vHpsa8ZV0ox6DHosa0xrZ3xrjGusiBx7MgIkhlbGxvIEfIi8WWIinHvsiAxZbIgynGh8e2xorHrXR5IMalx70KW8SlxI7IgigjaGVhxb5uZ8ifx45oxJ9oKGbGqMeHxZd0yJ_GksipUkVBRE1FLm1kyIMuLi_JhMmGyYjJimTItsihcsiRYcSlxLkgxIJ0aMiox47Gn8eRyZhmxIbFl8WhLWZ1yJLIqMe_yJfIglvGpTFdx77Js106IMiFxrLIh8elybDIjciPyJHIk8iVybAixpzIocmjxYfJpcmnbsmpxa3IkmHGscWqya7GpTJdW8m1yKnKlcm4ybrGsMm8x6TIicicxaLGv8iOyJDIksiUyJbHp2XKhseNyojHuMSayovJmMqNZS1zaG9ydGPGo8qUxpkzypnJssq-ypzJu8ejyIjIisqqyoDKpsqDyqnIgcqsyLd0bWzJoWHJusmlPSLLhMm9yqHJv8a_Ij7KojwvYceexpUgScSUZ8aLyofGicqJxJrHusSQx7zJgiFbx6zHrsiDy5kvdceEb8iyLndpa2nFmsW-YS7KuGfGtcyAaXDFqmlhL8WXy6LLojkvRXjHg8a9anBnyI7MlsyYx7zLp2HLqciZy6vHt8SwxqDGp8WnyozJqcmrya3Lssu0zJfHrcidW8yCzKJlybTHvsy1y6nJtMm5y7jLusiTy73Lv8yBzIPMjsyGcsyIzYLMi8yNzI_MkcyPYcyUzJ7MssWizJrMnCLNkceuy6bLqMqrzKXHj8ynyaTMqsqyyo7HlGzKkcSFZMioy7PMumXKlsqYzLnNmsqWzL3KnsejzL_LvGTLvsyKzYTMhcyHzInMgcyMzITMkG7Mks2PzJXMsceuLs2UzJ3OhcaDzKHMo82cy63MqcmmzaHKtMq2yrjKusq8zK_Nqsq_za7Mtsq_zbHHocqfzbTNgc24zYvNhs2IzIrNvsyOzoDOgs2QzorNk8ybzonMn82ZzLbLjsihxq_LkcmhzILMnHPFoMuXzL7Lu86izYPOpM27zYnOqM2MzoHNjs6szJ_Oh8yby57GnMW-dj48zrkgzrtjzr3Nssa0zqHNts2JzbnOpc28zYrNv82NzJPOhM-KzZTLns-Sbc66zrzLmM-Yy7nOv8-bzqPMhM-ez4TNi86qz4jPpM2Sz4tnz6cvz4_Hqs--CiDGh8-Tz5XPl86fzbPPr823z4HPss-DzqfPtc-izoPNl8yZz4zGrdCCz6jPqs-Wz6zQh8-Z0InPnM-CzYfPn8-Fz7bPo9CSzq7Pu8aty6HQgMaUxpbOjMe8y7_JnyDLlMalx77Ls8u1yJ3IhM-tz5rQisyC0J_Ops290I_Ph9Ckzq3Pus6wzZLOssyjKcu3z63Fl9C7z4XPs8yKL0bFlWU60KXPusia0KsgQ8eLxZrEkcabyKnGtMqcxpYoVGjFvyBiZci4xLlzyKbMgMe8y5TGv9GdyYDRoC_RosiO0aXRp9Gp0avGi9Gux5rQsSDRssi_yoZb0aHJucaWJ9G50a3Ru2HRrNG-0bDSgdGcyL8n0bXKnDzGhtGk0abSi9Gq0o3RvcSP0b_RsdKSxJHImtKF0bbJudKX0bjSmtGo0pzSjtKf0pDSgsSR0oTShsaHxobSidKq0ozSrdGv0oDSsHTSlNGZT8mfxLrJtsaZTG9jYWzMuMqa04TThtOIzLwgyZDJhcmHyYnJi8qlyoLIlMmR05PKrFvFqcS5clXNpsqcL0xJQ0VOU0XIjtOdxIbToMWqy47QgNCW0ITPq86-zYDPsNCLzYXQjdC_z6HRgdCR0YPPps-Rx5fQlcaHy5Roy5bQmsiGyqDLh8iMy53Ln8mwy6HLozzUgtCB0IPPqc-U07TQudCdz7HTudCgz7TTvM6rz7jOhtSA1JJy0KjPvWnPkAo}).
 
@@ -46,7 +46,7 @@ And more...
 
 ### Patterns
 
-Only **regular expressions** are used for URIs pattern matching. You can define the pattern you want to inspect by yourself.
+Only **regular expressions** are allowed for URIs pattern matching. You can define the pattern you want to inspect by yourself.
 
 ### Allowed URIs
 
@@ -130,6 +130,7 @@ import type { Options } from "textlint-rule-allowed-uris";
                 links: [/example/],
                 images: [/example/],
               },
+              checkUnusedDefinitions: false,
             }
           }
         }
@@ -155,6 +156,7 @@ import type { Options } from "textlint-rule-allowed-uris";
                 links: [/example/],
                 images: [/example/],
               },
+              checkUnusedDefinitions: false,
             }
           }
         }
@@ -180,6 +182,7 @@ import type { Options } from "textlint-rule-allowed-uris";
                 // links: [], => turned off
                 images: [/example/],
               },
+              checkUnusedDefinitions: false,
             }
           }
         }
@@ -205,6 +208,7 @@ import type { Options } from "textlint-rule-allowed-uris";
                 links: [/example/],
                 // images: [], => turned off
               },
+              checkUnusedDefinitions: false,
             }
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2759,14 +2759,14 @@
       }
     },
     "node_modules/cacheable": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
-      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
+      "integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.10.0",
-        "keyv": "^5.4.0"
+        "hookified": "^1.11.0",
+        "keyv": "^5.5.0"
       }
     },
     "node_modules/cacheable/node_modules/keyv": {
@@ -2872,9 +2872,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-      "integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4664,13 +4664,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
-      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.4.tgz",
+      "integrity": "sha512-5XRUFc0WTtUbjfGzEwXc42tiGxQHBmtbUG1h9L2apu4SulCGN3Hqm//9D6FAolf8MYNL7f/YlJl9vy08pj5JuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^6.1.12"
+        "flat-cache": "^6.1.13"
       }
     },
     "node_modules/fill-range": {
@@ -4700,15 +4700,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
-      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
+      "integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cacheable": "^1.10.3",
+        "cacheable": "^1.10.4",
         "flatted": "^3.3.3",
-        "hookified": "^1.10.0"
+        "hookified": "^1.11.0"
       }
     },
     "node_modules/flatted": {
@@ -5121,9 +5121,9 @@
       }
     },
     "node_modules/hookified": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.10.0.tgz",
-      "integrity": "sha512-dJw0492Iddsj56U1JsSTm9E/0B/29a1AuoSLRAte8vQg/kaTGF3IgjEWT8c8yG4cC10+HisE1x5QAwR0Xwc+DA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
+      "integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
This pull request makes several improvements and clarifications to the `README.md` for the `textlint-rule-allowed-uris` package. The main updates include clarifying documentation around URI pattern matching, improving example links, and updating configuration examples to include a new option.

**Documentation improvements:**

* Updated the link to detailed Markdown examples to point directly to the "links" section for better navigation.
* Clarified the language to state that only regular expressions are allowed for URI pattern matching, making the restriction explicit.

**Configuration example updates:**

* Added the `checkUnusedDefinitions: false` option to all configuration examples to document this available setting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R211)